### PR TITLE
Add tokens for `!` and `?`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 **Features**
 
 - Added support for array literal syntax in `for` loop expressions. Previously array literals were only allowed in output statements and the `assign` tag. For example, `{% for x in some.thing, 42, true %}`.
+- Add tokens for symbols `!` and `?`. These tokens are not used by any default Liquid expression, but can be used by custom tags.
 
 ## Version 0.1.0
 

--- a/liquid2/builtin/expressions.py
+++ b/liquid2/builtin/expressions.py
@@ -689,7 +689,7 @@ class TernaryFilteredExpression(Expression):
         """Return a new TernaryFilteredExpression parsed from tokens in _stream_."""
         stream.expect(TokenType.IF)
         stream.next()  # move past `if`
-        condition = BooleanExpression.parse(stream)
+        condition = BooleanExpression.parse(stream, inline=True)
         alternative: Expression | None = None
         filters: list[Filter] | None = None
         tail_filters: list[Filter] | None = None
@@ -949,9 +949,15 @@ class BooleanExpression(Expression):
         return is_truthy(await self.expression.evaluate_async(context))
 
     @staticmethod
-    def parse(stream: TokenStream) -> BooleanExpression:
-        """Return a new BooleanExpression parsed from tokens in _stream_."""
+    def parse(stream: TokenStream, *, inline: bool = False) -> BooleanExpression:
+        """Return a new BooleanExpression parsed from tokens in _stream_.
+
+        If _inline_ is `False`, we expect the stream to be empty after parsing
+        a Boolean expression and will raise a syntax error if it's not.
+        """
         expr = parse_boolean_primitive(stream)
+        if not inline:
+            stream.expect_eos()
         return BooleanExpression(expr.token, expr)
 
     def children(self) -> list[Expression]:

--- a/liquid2/lexer.py
+++ b/liquid2/lexer.py
@@ -87,6 +87,8 @@ class Lexer:
         "COMMA": r",",
         "PIPE": r"\|",
         "LBRACKET": r"\[",
+        "EXCLAIM": r"!",
+        "QUESTION": r"\?",
     }
 
     NUMBERS: dict[str, str] = {
@@ -135,6 +137,8 @@ class Lexer:
         "COLON": TokenType.COLON,
         "COMMA": TokenType.COMMA,
         "PIPE": TokenType.PIPE,
+        "EXCLAIM": TokenType.EXCLAIM,
+        "QUESTION": TokenType.QUESTION,
     }
 
     MARKUP: dict[str, str] = {
@@ -687,7 +691,7 @@ class Lexer:
                 self.accept_range()
                 self.in_range = False
         else:
-            msg = f"unexpected token {self.source[self.start:self.pos]!r}"
+            msg = f"unexpected token {self.source[self.start : self.pos]!r}"
             raise LiquidSyntaxError(
                 msg,
                 token=ErrorToken(
@@ -708,7 +712,7 @@ class Lexer:
         if self.pos != self.start:
             msg = (
                 "must emit or ignore before consuming whitespace "
-                f"({self.source[self.start: self.pos]!r}:{self.pos})"
+                f"({self.source[self.start : self.pos]!r}:{self.pos})"
             )
             raise Exception(msg)
 
@@ -723,7 +727,7 @@ class Lexer:
         if self.pos != self.start:
             msg = (
                 "must emit or ignore before consuming whitespace "
-                f"({self.source[self.start: self.pos]!r}:{self.pos})"
+                f"({self.source[self.start : self.pos]!r}:{self.pos})"
             )
             raise Exception(msg)
 
@@ -739,7 +743,7 @@ class Lexer:
         if self.pos != self.start:
             msg = (
                 "must emit or ignore before consuming whitespace "
-                f"({self.source[self.start: self.pos]!r}:{self.pos})"
+                f"({self.source[self.start : self.pos]!r}:{self.pos})"
             )
             raise Exception(msg)
 
@@ -784,9 +788,9 @@ class Lexer:
             match = self.MARKUP_RULES.match(self.source, pos=self.pos)
 
             if not match:
-                assert self.pos == len(
-                    self.source
-                ), f"{self.pos}:{self.source[self.pos: 10]!r}.."
+                assert self.pos == len(self.source), (
+                    f"{self.pos}:{self.source[self.pos : 10]!r}.."
+                )
                 return None
 
             kind = match.lastgroup

--- a/liquid2/token.py
+++ b/liquid2/token.py
@@ -423,6 +423,7 @@ class TokenType(Enum):
     DOUBLE_QUOTE_TEMPLATE_STRING = auto()
     ELSE = auto()
     EQ = auto()
+    EXCLAIM = auto()  # '!', not used in any default expression
     FALSE = auto()
     FLOAT = auto()
     FOR = auto()
@@ -439,6 +440,7 @@ class TokenType(Enum):
     NULL = auto()
     OR_WORD = auto()  # or
     PIPE = auto()
+    QUESTION = auto()  # '?', not used in any default expression
     REQUIRED = auto()
     RPAREN = auto()
     SINGLE_QUOTE_STRING = auto()

--- a/tests/test_liquid_syntax_errors.py
+++ b/tests/test_liquid_syntax_errors.py
@@ -107,7 +107,7 @@ test_cases = [
     Case(
         description="unknown infix operator",
         template="{% if 1 =! 2 %}ok{% endif %}",
-        expect_msg="unexpected '!'",
+        expect_msg="unexpected token ASSIGN",
     ),
     Case(
         description="bad 'unless' expression",
@@ -120,7 +120,7 @@ test_cases = [
         expect_msg=r"unexpected '\$'",
     ),
     Case(
-        description="unknown infix operator",
+        description="unknown symbol",
         template="{% if 1 ~ 2 %}ok{% endif %}",
         expect_msg="unexpected '~'",
     ),


### PR DESCRIPTION
Add tokens for symbols `!` and `?`. These tokens are not used by any default Liquid expression, but can be used by custom tags.