### PR TITLE
Create SECURITY.md

### DIFF
--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -1,0 +1,15 @@
+# Security Policy
+
+## Reporting security issues
+
+**Please report security issues by emailing pythonliquid22@gmail.com.**
+
+Normal issues, without security implications, should be reported to the [issue tracker](https://github.com/jg-rp/python-liquid2/issues). If you believe you've found an issue with Python Liquid2 that does have security implications, please send a description of the issue, including code necessary to reproduce it, to pythonliquid22@gmail.com.
+
+You will receive an email acknowledging receipt of the issue within no more than 48 hours (probably less). We aim to release fixes for security issues within 1 week of initial disclosure. Longer if more information is required, in which case you'll be contacted with a request for further details.
+
+## Supported Versions
+
+At any point in time, the last two (at least) major versions of Python Liquid2 will receive security updates for at least three years after initial release.
+
+Older (not the latest), minor releases do not officially receive security updates, but might be available upon request.


### PR DESCRIPTION
This PR adds a `.github/SECURITY.md` file describing how to report suspected vulnerabilities privately and what information should be included in a report

This gives users and security researchers a clear responsible disclosure process and helps avoid accidental public disclosure of security-sensitive details
