### PR TITLE
Fix file system loader and test against Python 3.14

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -9,7 +9,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        python-version: ["3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
     steps:
       - uses: actions/checkout@v4
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 **Fixes**
 
+- Fixed the built-in `FileSystemLoader` and `CachingFileSystemLoader`. Previously they would allow a malicious template author to read files outside the template search path when giving an absolute file path to `{% include %}` or `{% render %}`. See https://github.com/jg-rp/liquid/security/advisories/GHSA-8p4x-wr7x-3788.  
 - Fixed some corner cases with `find`, `find_index` and `has` filters.
 
 **Features**

--- a/liquid2/ast.py
+++ b/liquid2/ast.py
@@ -39,7 +39,7 @@ class Node(ABC):
         """If True, indicates that the node, when rendered, produces no output text
         or only whitespace.
         
-        The output node (`{{ something }}`) and echo tag are exception. Even if they
+        The output node (`{{ something }}`) and echo tag are exceptions. Even if they
         evaluate to an empty or blank string, they are not considered "blank".
         """
 

--- a/liquid2/builtin/loaders/caching_file_system_loader.py
+++ b/liquid2/builtin/loaders/caching_file_system_loader.py
@@ -20,6 +20,8 @@ class CachingFileSystemLoader(CachingLoaderMixin, FileSystemLoader):
         search_path: One or more paths to search.
         encoding: Open template files with the given encoding.
         ext: A default file extension. Should include a leading period.
+        reject_symlinks: When `True`, reject paths to symlinks that resolve to files
+            outside the search path. Defaults to `False`.
         auto_reload: If `True`, automatically reload a cached template if it has been
             updated.
         namespace_key: The name of a global render context variable or loader keyword
@@ -38,6 +40,7 @@ class CachingFileSystemLoader(CachingLoaderMixin, FileSystemLoader):
         encoding: str = "utf-8",
         ext: str | None = None,
         *,
+        reject_symlinks: bool = False,
         auto_reload: bool = True,
         namespace_key: str = "",
         capacity: int = 300,
@@ -53,4 +56,5 @@ class CachingFileSystemLoader(CachingLoaderMixin, FileSystemLoader):
             search_path=search_path,
             encoding=encoding,
             ext=ext,
+            reject_symlinks=reject_symlinks,
         )

--- a/liquid2/builtin/loaders/file_system_loader.py
+++ b/liquid2/builtin/loaders/file_system_loader.py
@@ -25,6 +25,8 @@ class FileSystemLoader(BaseLoader):
         search_path: One or more paths to search.
         encoding: Encoding to use when opening files.
         ext: A default file extension. Should include a leading period.
+        reject_symlinks: When `True`, reject paths to symlinks that resolve to files
+            outside the search path. Defaults to `False`.
     """
 
     def __init__(
@@ -33,6 +35,7 @@ class FileSystemLoader(BaseLoader):
         *,
         encoding: str = "utf-8",
         ext: str | None = None,
+        reject_symlinks: bool = False,
     ):
         super().__init__()
         if not isinstance(search_path, Iterable) or isinstance(search_path, str):
@@ -41,6 +44,7 @@ class FileSystemLoader(BaseLoader):
         self.search_path = [Path(path) for path in search_path]
         self.encoding = encoding
         self.ext = ext
+        self.reject_symlinks = reject_symlinks
 
     def resolve_path(self, template_name: str) -> Path:
         """Return a path to the template identified by _template_name_.
@@ -54,14 +58,27 @@ class FileSystemLoader(BaseLoader):
         if self.ext and not template_path.suffix:
             template_path = template_path.with_suffix(self.ext)
 
-        if os.path.pardir in template_path.parts:
+        if os.path.pardir in template_path.parts or template_path.is_absolute():
             raise TemplateNotFoundError(template_name)
 
-        for path in self.search_path:
-            source_path = path.joinpath(template_path)
-            if not source_path.exists():
+        for base in self.search_path:
+            source_path = base.joinpath(template_path)
+
+            if not source_path.exists() or not source_path.is_file():
                 continue
+
+            if self.reject_symlinks:
+                try:
+                    resolved = source_path.resolve(strict=False)
+                    base_resolved = base.resolve(strict=False)
+                except OSError:
+                    continue
+
+                if not resolved.is_relative_to(base_resolved):
+                    continue
+
             return source_path
+
         raise TemplateNotFoundError(template_name)
 
     def _read(self, source_path: Path) -> tuple[str, float]:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,7 @@ classifiers = [
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
   "Programming Language :: Python :: 3.13",
+  "Programming Language :: Python :: 3.14",
   "Programming Language :: Python :: Implementation :: CPython",
   "Programming Language :: Python :: Implementation :: PyPy",
 ]
@@ -176,6 +177,7 @@ ignore = [
   "PLR0912",
   "PLR0913",
   "PLR0915",
+  "PLW1641",
   "SIM108",
   "PT001",
   "S704",

--- a/tests/test_file_system_loader.py
+++ b/tests/test_file_system_loader.py
@@ -1,4 +1,5 @@
 import asyncio
+import sys
 import tempfile
 import time
 from pathlib import Path
@@ -106,6 +107,54 @@ def test_stay_in_search_path() -> None:
     env = Environment(loader=FileSystemLoader("tests/fixtures/001/snippets"))
     with pytest.raises(TemplateNotFoundError):
         env.get_template("../main.html")
+
+
+def test_reject_absolute_paths() -> None:
+    with (
+        tempfile.TemporaryDirectory() as root,
+        tempfile.TemporaryDirectory() as private,
+    ):
+        private_file = Path(private) / "secret.liquid"
+        private_file.write_text("SECRET")
+
+        env = Environment(loader=FileSystemLoader(root))
+
+        with pytest.raises(TemplateNotFoundError):
+            env.get_template(str(private_file))
+
+        with pytest.raises(TemplateNotFoundError):
+            env.from_string(f"{{% render '{private_file}' %}}").render()
+
+
+@pytest.mark.skipif(
+    sys.platform == "win32",
+    reason="Symlinks require special permissions on Windows",
+)
+def test_reject_symlink_outside_search_path() -> None:
+    with (
+        tempfile.TemporaryDirectory() as root,
+        tempfile.TemporaryDirectory() as private,
+    ):
+        root_path = Path(root)
+        private_path = Path(private)
+
+        # Create a "secret" file outside the search path
+        private_file = private_path / "secret.liquid"
+        private_file.write_text("SECRET")
+
+        # Create a symlink inside the search path pointing to the private file
+        symlink_path = root_path / "link.liquid"
+        symlink_path.symlink_to(private_file)
+
+        env = Environment(loader=FileSystemLoader(root_path, reject_symlinks=True))
+
+        # Attempt to load the symlink directly
+        with pytest.raises(TemplateNotFoundError):
+            env.get_template("link.liquid")
+
+        # Attempt to render via the render tag
+        with pytest.raises(TemplateNotFoundError):
+            env.from_string("{% render 'link.liquid' %}").render()
 
 
 def test_dont_cache_templates() -> None:

--- a/tests/test_file_system_loader.py
+++ b/tests/test_file_system_loader.py
@@ -109,6 +109,10 @@ def test_stay_in_search_path() -> None:
         env.get_template("../main.html")
 
 
+@pytest.mark.skipif(
+    sys.platform == "win32",
+    reason="Avoid escaping Windows paths",
+)
 def test_reject_absolute_paths() -> None:
     with (
         tempfile.TemporaryDirectory() as root,


### PR DESCRIPTION
This PR fixes the built-in `FileSystemLoader` and `CachingFileSystemLoader`. Previously they would allow a malicious template author to read files outside the template search path when giving an absolute file path to `{% include %}` or `{% render %}`. See https://github.com/jg-rp/liquid/security/advisories/GHSA-8p4x-wr7x-3788.  